### PR TITLE
Adds thumbnails for media, also configures caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 New version of badparking.in.ua. Now with mobile apps.
 
 # Local installation
-* Install python 3.5 and postgresql.
+* Install python 3.4+, postgresql and redis.
+* Install libffi-dev and libssl-dev
 * Install virtualenv
 * Clone repository
 * Create virtualenv outside of repo: `virtualenv venv`

--- a/badparking/badparking/settings.py
+++ b/badparking/badparking/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework_swagger',
     'django_filters',
+    'imagekit',
     'core',
     'front',
     'mobile_api',
@@ -92,6 +93,23 @@ DATABASES = {
 }
 
 
+# Cache framework configuration
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/1',
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            'PARSER_CLASS': 'redis.connection.HiredisParser',
+        }
+    }
+}
+
+
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+SESSION_CACHE_ALIAS = 'default'
+
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 
@@ -111,6 +129,8 @@ AUTH_USER_MODEL = 'profiles.User'
 STATIC_URL = '/static/'
 MEDIA_ROOT = normpath(join(BASE_DIR, '../image_storage'))
 MEDIA_URL = '/media/'
+
+IMAGEKIT_SPEC_CACHEFILE_NAMER = 'imagekit.cachefiles.namers.hash'
 
 
 SWAGGER_SETTINGS = {

--- a/badparking/core/admin.py
+++ b/badparking/core/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from django.utils.html import format_html
+from imagekit.admin import AdminThumbnail
+
 from .models import CrimeType, Claim, ClaimState
 
 
@@ -14,11 +15,8 @@ class CrimeTypeAdmin(admin.ModelAdmin):
 class MediaInline(admin.TabularInline):
     model = Claim.media.through
     raw_id_fields = ('mediafilemodel',)
-    readonly_fields = ('image',)
-
-    def image(self, obj):
-        return format_html('<a href="{}"><img src="{}" width="100" height="100" /></a>',
-                           obj.mediafilemodel.file.url, obj.mediafilemodel.file.url)
+    readonly_fields = ('admin_thumbnail',)
+    admin_thumbnail = AdminThumbnail(image_field=lambda obj: obj.mediafilemodel.thumbnail)
 
 
 class ClaimStateInline(admin.TabularInline):

--- a/badparking/media/models.py
+++ b/badparking/media/models.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 from datetime import datetime
 
 from django.db import models
+from imagekit.models import ImageSpecField
+from imagekit.processors import ResizeToFill
 
 
 def generate_upload_path(instance, filename):
@@ -11,6 +13,10 @@ def generate_upload_path(instance, filename):
 
 class MediaFileModel(models.Model):
     file = models.ImageField(upload_to=generate_upload_path)
+    thumbnail = ImageSpecField(source='file',
+                               processors=[ResizeToFill(100, 100)],
+                               format='JPEG',
+                               options={'quality': 60})
     original_filename = models.CharField(max_length=255, default='')
     created_at = models.DateTimeField(editable=False, auto_now_add=True)
 

--- a/badparking/mobile_api/serializers.py
+++ b/badparking/mobile_api/serializers.py
@@ -14,9 +14,12 @@ class CrimeTypeSerializer(serializers.ModelSerializer):
 
 
 class MediaFileSerializer(serializers.ModelSerializer):
+    # Specifying this explicitly as DRF doesn't have a mapping for ImageKit, thus unaware it should grab the URL
+    thumbnail = serializers.ImageField(read_only=True)
+
     class Meta:
         model = MediaFileModel
-        fields = ('file', 'original_filename')
+        fields = ('file', 'thumbnail', 'original_filename')
         read_only_fields = ('original_filename',)
 
     def create(self, validated_data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ Markdown==2.6.6
 psycopg2==2.6.1
 Pillow==3.2.0
 requests==2.10.0
-# Requires libffi-dev and libssl-dev to be installed on the system
 cryptography==1.3.2
 facebook-sdk==1.0.0
+django-imagekit==3.3
+redis==2.10.5
+hiredis==0.2.0
+django-redis==4.4.3


### PR DESCRIPTION
Adds django-imagekit as a dependency for thumbnailing. `MediaFileModel`
configures one thumbnail spec for now (100x100), may add more later.
This is easy as ImageKit model fields are not real DB fields, just
specs.

API media serializer also returns this thumbnail now for all related
resources.

Throwing it Redis as caching and sessions dependency. It's utilised by
ImageKit to avoid unnecessary storage I/O, we may also do some API caching
later on and Redis may be useful for the upcoming moderation
improvements.

Closes #12.
